### PR TITLE
Add first name and last name to user records

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -869,7 +869,9 @@
     "github.com/gobuffalo/buffalo",
     "github.com/gobuffalo/buffalo-pop/pop/popmw",
     "github.com/gobuffalo/buffalo/render",
+    "github.com/gobuffalo/buffalo/runtime",
     "github.com/gobuffalo/envy",
+    "github.com/gobuffalo/flect",
     "github.com/gobuffalo/mw-csrf",
     "github.com/gobuffalo/mw-forcessl",
     "github.com/gobuffalo/mw-i18n",
@@ -878,8 +880,13 @@
     "github.com/gobuffalo/packr/v2",
     "github.com/gobuffalo/pop",
     "github.com/gobuffalo/suite",
+    "github.com/gobuffalo/uuid",
+    "github.com/gobuffalo/validate",
+    "github.com/gobuffalo/validate/validators",
     "github.com/markbates/grift/grift",
+    "github.com/pkg/errors",
     "github.com/unrolled/secure",
+    "golang.org/x/crypto/bcrypt",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/actions/auth_test.go
+++ b/actions/auth_test.go
@@ -13,6 +13,8 @@ func (as *ActionSuite) Test_Auth_New() {
 func (as *ActionSuite) Test_Auth_Create() {
 	u := &models.User{
 		Email:                "mark@example.com",
+		FirstName:            "Mark",
+		LastName:             "Example",
 		Password:             "password",
 		PasswordConfirmation: "password",
 	}
@@ -28,6 +30,8 @@ func (as *ActionSuite) Test_Auth_Create() {
 func (as *ActionSuite) Test_Auth_Create_Redirect() {
 	u := &models.User{
 		Email:                "mark@example.com",
+		FirstName:            "Mark",
+		LastName:             "Example",
 		Password:             "password",
 		PasswordConfirmation: "password",
 	}
@@ -55,6 +59,8 @@ func (as *ActionSuite) Test_Auth_Create_UnknownUser() {
 func (as *ActionSuite) Test_Auth_Create_BadPassword() {
 	u := &models.User{
 		Email:                "mark@example.com",
+		FirstName:            "Mark",
+		LastName:             "Example",
 		Password:             "password",
 		PasswordConfirmation: "password",
 	}

--- a/actions/home_test.go
+++ b/actions/home_test.go
@@ -11,6 +11,8 @@ func (as *ActionSuite) Test_HomeHandler() {
 func (as *ActionSuite) Test_HomeHandler_LoggedIn() {
 	u := &models.User{
 		Email:                "mark@example.com",
+		FirstName:            "Mark",
+		LastName:             "Example",
 		Password:             "password",
 		PasswordConfirmation: "password",
 	}

--- a/actions/users_test.go
+++ b/actions/users_test.go
@@ -16,6 +16,8 @@ func (as *ActionSuite) Test_Users_Create() {
 
 	u := &models.User{
 		Email:                "mark@example.com",
+		FirstName:            "Mark",
+		LastName:             "Example",
 		Password:             "password",
 		PasswordConfirmation: "password",
 	}

--- a/assets/css/application.scss
+++ b/assets/css/application.scss
@@ -11,3 +11,20 @@
   padding: 0 .625rem;
   text-align: center;
 }
+
+.auth-wrapper {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+
+  .sign-form {
+    max-width: 21.875rem;
+    padding: 0 1.25rem;
+    width: 100%;
+  }
+
+  h1 {
+    margin-bottom: 1.25rem;
+  }
+}

--- a/assets/css/application.scss
+++ b/assets/css/application.scss
@@ -7,9 +7,8 @@
   margin-right: .625rem;
 }
 
-.account-name {
-  padding: 0 .625rem;
-  text-align: center;
+.dropdown a:hover {
+  text-decoration: none;
 }
 
 .auth-wrapper {

--- a/migrations/20190322002508_create_users.up.fizz
+++ b/migrations/20190322002508_create_users.up.fizz
@@ -1,7 +1,7 @@
 create_table("users"){
     t.Column("id", "uuid", {"primary": true})
-    t.Column("email", "string", {})
+    t.Column("email", "string", {null: false})
+    t.Column("first_name", "string", {null: false})
+    t.Column("last_name", "string", {})
     t.Column("password_hash", "string", {})
-
-    
 }

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -36,7 +36,9 @@ ALTER TABLE public.schema_migration OWNER TO greenretro;
 
 CREATE TABLE public.users (
     id uuid NOT NULL,
-    email character varying(255) NOT NULL,
+    email character varying(255),
+    first_name character varying(255),
+    last_name character varying(255) NOT NULL,
     password_hash character varying(255) NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL

--- a/models/user.go
+++ b/models/user.go
@@ -19,6 +19,8 @@ type User struct {
 	CreatedAt    time.Time `json:"created_at" db:"created_at"`
 	UpdatedAt    time.Time `json:"updated_at" db:"updated_at"`
 	Email        string    `json:"email" db:"email"`
+	FirstName    string    `json:"first_name" db:"first_name"`
+	LastName     string    `json:"last_name" db:"last_name"`
 	PasswordHash string    `json:"password_hash" db:"password_hash"`
 
 	Password             string `json:"-" db:"-"`
@@ -58,6 +60,7 @@ func (u *User) Validate(tx *pop.Connection) (*validate.Errors, error) {
 	var err error
 	return validate.Validate(
 		&validators.StringIsPresent{Field: u.Email, Name: "Email"},
+		&validators.StringIsPresent{Field: u.FirstName, Name: "FirstName", Message: "Name can not be blank."},
 		&validators.StringIsPresent{Field: u.PasswordHash, Name: "PasswordHash"},
 		// check to see if the email address is already taken:
 		&validators.FuncValidator{

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -11,6 +11,8 @@ func (ms *ModelSuite) Test_User_Create() {
 
 	u := &models.User{
 		Email:                "mark@example.com",
+		FirstName:            "Mark",
+		LastName:             "Example",
 		Password:             "password",
 		PasswordConfirmation: "password",
 	}
@@ -24,6 +26,75 @@ func (ms *ModelSuite) Test_User_Create() {
 	count, err = ms.DB.Count("users")
 	ms.NoError(err)
 	ms.Equal(1, count)
+}
+
+func (ms *ModelSuite) TestUserCreateWithMissingEmail() {
+	count, err := ms.DB.Count("users")
+	ms.NoError(err)
+	ms.Equal(0, count)
+
+	u := &models.User{
+		Password:             "password",
+		PasswordConfirmation: "password",
+	}
+	ms.Zero(u.PasswordHash)
+
+	verrs, err := u.Create(ms.DB)
+	ms.NoError(err)
+	ms.True(verrs.HasAny())
+	ms.Equal(1, len(verrs.Keys()))
+	ms.Equal("email", verrs.Keys()[0])
+	ms.EqualError(verrs, "Email can not be blank.")
+
+	count, err = ms.DB.Count("users")
+	ms.NoError(err)
+	ms.Equal(0, count)
+}
+
+func (ms *ModelSuite) TestUserCreateWithMissingPassword() {
+	count, err := ms.DB.Count("users")
+	ms.NoError(err)
+	ms.Equal(0, count)
+
+	u := &models.User{
+		Email: "mark@example.com",
+	}
+	ms.Zero(u.PasswordHash)
+
+	verrs, err := u.Create(ms.DB)
+	ms.NoError(err)
+	ms.True(verrs.HasAny())
+	ms.Equal(1, len(verrs.Keys()))
+	ms.Equal("password", verrs.Keys()[0])
+	ms.EqualError(verrs, "Password can not be blank.")
+
+	count, err = ms.DB.Count("users")
+	ms.NoError(err)
+	ms.Equal(0, count)
+}
+
+func (ms *ModelSuite) TestUserCreateWithMissingFirstName() {
+	count, err := ms.DB.Count("users")
+	ms.NoError(err)
+	ms.Equal(0, count)
+
+	u := &models.User{
+		Email:                "mark@example.com",
+		Password:             "password",
+		PasswordConfirmation: "password",
+	}
+	ms.Zero(u.PasswordHash)
+
+	verrs, err := u.Create(ms.DB)
+	ms.NoError(err)
+	ms.True(verrs.HasAny())
+	ms.Equal(1, len(verrs.Keys()))
+	ms.Equal("name", verrs.Keys()[0])
+	ms.EqualError(verrs, "Name can not be blank.")
+
+	count, err = ms.DB.Count("users")
+	ms.NoError(err)
+	ms.Equal(0, count)
 }
 
 func (ms *ModelSuite) Test_User_Create_ValidationErrors() {

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -34,6 +34,8 @@ func (ms *ModelSuite) TestUserCreateWithMissingEmail() {
 	ms.Equal(0, count)
 
 	u := &models.User{
+		FirstName:            "Mark",
+		LastName:             "Example",
 		Password:             "password",
 		PasswordConfirmation: "password",
 	}
@@ -42,6 +44,7 @@ func (ms *ModelSuite) TestUserCreateWithMissingEmail() {
 	verrs, err := u.Create(ms.DB)
 	ms.NoError(err)
 	ms.True(verrs.HasAny())
+	ms.T().Log("Validation errors: ", verrs)
 	ms.Equal(1, len(verrs.Keys()))
 	ms.Equal("email", verrs.Keys()[0])
 	ms.EqualError(verrs, "Email can not be blank.")
@@ -57,7 +60,9 @@ func (ms *ModelSuite) TestUserCreateWithMissingPassword() {
 	ms.Equal(0, count)
 
 	u := &models.User{
-		Email: "mark@example.com",
+		Email:     "mark@example.com",
+		FirstName: "Mark",
+		LastName:  "Example",
 	}
 	ms.Zero(u.PasswordHash)
 
@@ -89,7 +94,7 @@ func (ms *ModelSuite) TestUserCreateWithMissingFirstName() {
 	ms.NoError(err)
 	ms.True(verrs.HasAny())
 	ms.Equal(1, len(verrs.Keys()))
-	ms.Equal("name", verrs.Keys()[0])
+	ms.Equal("first_name", verrs.Keys()[0])
 	ms.EqualError(verrs, "Name can not be blank.")
 
 	count, err = ms.DB.Count("users")
@@ -123,6 +128,8 @@ func (ms *ModelSuite) Test_User_Create_UserExists() {
 
 	u := &models.User{
 		Email:                "mark@example.com",
+		FirstName:            "Mark",
+		LastName:             "Example",
 		Password:             "password",
 		PasswordConfirmation: "password",
 	}

--- a/templates/auth/new.html
+++ b/templates/auth/new.html
@@ -1,22 +1,3 @@
-<style>
-  .auth-wrapper{
-    height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .auth-wrapper .sign-form{
-    max-width: 21.875rem;
-    width: 100%;
-    padding: 0 1.25rem;
-  }
-
-  .auth-wrapper h1 {
-    margin-bottom: 1.25rem;
-  }
-</style>
-
 <div class="auth-wrapper">
   <div class="sign-form">
     <h1>Sign In</h1>

--- a/templates/layouts/application.html
+++ b/templates/layouts/application.html
@@ -30,7 +30,7 @@
         <%= if (current_user) { %>
           <li class="dropdown">
             <a class="dropdown-toggle text-white" data-toggle="dropdown" href="#">
-              <%= current_user.Email %>
+              <%= current_user.FirstName %>'s Team
               <span class="caret"></span>
             </a>
             <ul class="dropdown-menu dropdown-menu-right">

--- a/templates/users/new.html
+++ b/templates/users/new.html
@@ -1,28 +1,11 @@
-<style>
-  .auth-wrapper{
-    height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .auth-wrapper .sign-form{
-    max-width: 21.875rem;
-    width: 100%;
-    padding: 0 1.25rem;
-  }
-
-  .auth-wrapper h1 {
-    margin-bottom: 1.25rem;
-  }
-</style>
-
 <div class="auth-wrapper">
   <div class="sign-form">
     <h1>Register</h1>
 
     <%= form_for(user, {action: usersPath()}) { %>
-      <%= f.InputTag("Email") %>
+      <%= f.InputTag("First Name", {placeholder: "Gypsy"}) %>
+      <%= f.InputTag("Last Name", {placeholder: "Dog"}) %>
+      <%= f.InputTag("Email", {placeholder: "gypsy@example.com"}) %>
       <%= f.InputTag("Password", {type: "password"}) %>
       <%= f.InputTag("PasswordConfirmation", {type: "password"}) %>
 

--- a/templates/users/new.html
+++ b/templates/users/new.html
@@ -3,9 +3,9 @@
     <h1>Register</h1>
 
     <%= form_for(user, {action: usersPath()}) { %>
-      <%= f.InputTag("First Name", {placeholder: "Gypsy"}) %>
-      <%= f.InputTag("Last Name", {placeholder: "Dog"}) %>
-      <%= f.InputTag("Email", {placeholder: "gypsy@example.com"}) %>
+      <%= f.InputTag("FirstName", {}) %>
+      <%= f.InputTag("LastName", {}) %>
+      <%= f.InputTag("Email", {placeholder: "max@example.com"}) %>
       <%= f.InputTag("Password", {type: "password"}) %>
       <%= f.InputTag("PasswordConfirmation", {type: "password"}) %>
 


### PR DESCRIPTION
- Update schema migration to add `first_name` and `last_name` columns
    - Ensure `email` and `first_name` can't be null in the db
- Add first and last name fields to user model.
    - Add validations to ensure `FirstName` is set when a `User` is created.
- Update model tests to set `FirstName` and `LastName`, also expand tests to test each missing case separately.
- Add `First Name` and `Last Name` fields to user registration form.
- Change user indicator in nav bar from email to first name.