### PR TITLE
Create user's default team when they register

### DIFF
--- a/actions/users.go
+++ b/actions/users.go
@@ -1,9 +1,12 @@
 package actions
 
 import (
+	"net/http"
+
 	"github.com/gobuffalo/buffalo"
 	"github.com/gobuffalo/pop"
 	"github.com/jaymist/greenretro/models"
+	"github.com/jaymist/greenretro/services"
 	"github.com/pkg/errors"
 )
 
@@ -22,7 +25,7 @@ func UsersCreate(c buffalo.Context) error {
 	}
 
 	tx := c.Value("tx").(*pop.Connection)
-	verrs, err := u.Create(tx)
+	verrs, err := services.CreateUserAndTeam(tx, u)
 	if err != nil {
 		c.Flash().Add("danger", "Unable to create user account. Please correct the problem and try again.")
 		c.Logger().Error(err)
@@ -35,7 +38,7 @@ func UsersCreate(c buffalo.Context) error {
 
 		c.Set("user", u)
 		c.Set("errors", verrs)
-		return c.Render(200, r.HTML("users/new.html"))
+		return c.Render(http.StatusBadRequest, r.HTML("users/new.html"))
 	}
 
 	c.Session().Set("current_user_id", u.ID)

--- a/models/team.go
+++ b/models/team.go
@@ -36,11 +36,6 @@ func (t Teams) String() string {
 	return string(jt)
 }
 
-// Create a new team in the database
-func (t *Team) Create(tx *pop.Connection) (*validate.Errors, error) {
-	return tx.ValidateAndCreate(t)
-}
-
 // Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.
 // This method is not required and may be deleted.
 func (t *Team) Validate(tx *pop.Connection) (*validate.Errors, error) {

--- a/models/team_test.go
+++ b/models/team_test.go
@@ -13,7 +13,7 @@ func (ms *ModelSuite) Test_Team_Create() {
 		Name: "Mark's Team",
 	}
 
-	verrs, err := t.Create(ms.DB)
+	verrs, err := ms.DB.ValidateAndCreate(t)
 	ms.NoError(err)
 	ms.False(verrs.HasAny())
 
@@ -29,7 +29,7 @@ func (ms *ModelSuite) Test_Team_Create_Missing_Name() {
 
 	t := &models.Team{}
 
-	verrs, err := t.Create(ms.DB)
+	verrs, err := ms.DB.ValidateAndCreate(t)
 	ms.NoError(err)
 	ms.True(verrs.HasAny())
 	ms.Equal(1, len(verrs.Keys()))

--- a/services/user_team_create.go
+++ b/services/user_team_create.go
@@ -1,0 +1,26 @@
+package services
+
+import (
+	"fmt"
+
+	"github.com/gobuffalo/pop"
+	"github.com/gobuffalo/validate"
+	"github.com/jaymist/greenretro/models"
+)
+
+// CreateUserAndTeam creates a user and their corresponding team.
+func CreateUserAndTeam(tx *pop.Connection, u *models.User) (*validate.Errors, error) {
+	t := &models.Team{
+		Name: u.FirstName,
+	}
+
+	verrs, err := tx.ValidateAndCreate(t)
+	if err != nil || verrs.HasAny() {
+		return verrs, err
+	}
+
+	fmt.Printf("Creating user.")
+	u.Teams = append(u.Teams, *t)
+	verrs, err = u.Create(tx)
+	return verrs, err
+}

--- a/services/user_team_create.go
+++ b/services/user_team_create.go
@@ -1,8 +1,6 @@
 package services
 
 import (
-	"fmt"
-
 	"github.com/gobuffalo/pop"
 	"github.com/gobuffalo/validate"
 	"github.com/jaymist/greenretro/models"
@@ -10,17 +8,16 @@ import (
 
 // CreateUserAndTeam creates a user and their corresponding team.
 func CreateUserAndTeam(tx *pop.Connection, u *models.User) (*validate.Errors, error) {
-	t := &models.Team{
-		Name: u.FirstName,
-	}
-
-	verrs, err := tx.ValidateAndCreate(t)
+	verrs, err := u.Create(tx)
 	if err != nil || verrs.HasAny() {
 		return verrs, err
 	}
 
-	fmt.Printf("Creating user.")
-	u.Teams = append(u.Teams, *t)
-	verrs, err = u.Create(tx)
+	t := &models.Team{
+		Name:  u.FirstName,
+		Users: models.Users{*u},
+	}
+
+	verrs, err = tx.ValidateAndCreate(t)
 	return verrs, err
 }


### PR DESCRIPTION
When a user sign's up a team is automatically created for them.  The creation of the team and user is now deferred to a service function.  If any part of the db update should fail, then we the transaction should be rolled back and an error code sent to the client.